### PR TITLE
Add IsReadOnlyIgnoredAttribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ The `Parent` property on `ViewModel` internally uses a `WeakReference`.
 
 The `IsReadOnly` property does what it implies, if set to true, `SetProperty()` will now longer set any property or raise events on `INotifyPropertyChanged.PropertyChanged` except for the `IsReadOnly` property itself.
 
+Similar to the `IsDirtyIgnoredAttribute` there is a `IsReadOnlyIgnoredAttribute`. If present on a property the property can still be set when `IsReadOnly` is set to `true`.
+
 ### ValidatingViewModel
 
 Your viewmodel may also inherit from `ValidatingViewModel` which implements `IDataErrorInfo` and `INotifyDataErrorInfo`. 
@@ -246,6 +248,7 @@ Classes:
 - `PropertySourceAttribute: Attribute`: usable on properties of classes inheriting from `ComputedBindable` (e.g. `ViewModel`).
 - `CommandCanExecuteSourceAttribute: Attribute`: usable on any method called "CanExecute" in a class inheriting from either `ViewModelCommand<TViewModel>` or `AsyncViewModelCommand<TViewModel>`.
 - `IsDirtyIgnoredAttribute: Attribute`: usable on properties of classes inheriting from `ViewModel`.
+- `IsReadOnlyIgnoredAttribute: Attribute`: usable on properties of classes inheriting from `ViewModel`.
 
 ### Commands
 

--- a/src/Smaragd/Attributes/IsReadOnlyIgnoredAttribute.cs
+++ b/src/Smaragd/Attributes/IsReadOnlyIgnoredAttribute.cs
@@ -1,0 +1,20 @@
+﻿using System;
+
+namespace NKristek.Smaragd.Attributes
+{
+    /// <inheritdoc />
+    /// <summary>
+    /// This <see cref="Attribute"/> can be used on properties in classes inheriting from <see cref="T:NKristek.Smaragd.ViewModels.ViewModel" />.
+    /// <para />
+    /// It indicates, that a property can still be set even when <see cref="P:NKristek.Smaragd.ViewModels.ViewModel.IsReadOnly" /> is set to <c>true</c>.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property)]
+    public sealed class IsReadOnlyIgnoredAttribute
+        : Attribute
+    {
+        /// <summary>
+        /// Indicates if the attributes from the base class should be considered.
+        /// </summary>
+        public bool InheritAttributes { get; set; }
+    }
+}

--- a/src/Smaragd/ViewModels/ComputedBindable.cs
+++ b/src/Smaragd/ViewModels/ComputedBindable.cs
@@ -20,6 +20,8 @@ namespace NKristek.Smaragd.ViewModels
 
         internal HashSet<string> IsDirtyIgnoredProperties = new HashSet<string>();
 
+        internal HashSet<string> IsReadOnlyIgnoredProperties = new HashSet<string>();
+
         /// <inheritdoc />
         protected ComputedBindable()
         {
@@ -29,7 +31,8 @@ namespace NKristek.Smaragd.ViewModels
         private void InitAttributes()
         {
             var inheritPropertySource = new Dictionary<string, bool>();
-            var inheritIsDirty = new Dictionary<string, bool>();
+            var inheritIsDirtyIgnored = new Dictionary<string, bool>();
+            var inheritIsReadOnlyIgnored = new Dictionary<string, bool>();
 
             var currentType = GetType();
             while (currentType != null)
@@ -38,6 +41,8 @@ namespace NKristek.Smaragd.ViewModels
                 foreach (var property in properties)
                 {
                     var attributes = property.GetCustomAttributes(false);
+
+                    // PropertySourceAttribute
 
                     if (!inheritPropertySource.ContainsKey(property.Name) || inheritPropertySource[property.Name])
                     {
@@ -55,19 +60,39 @@ namespace NKristek.Smaragd.ViewModels
                         }
                     }
 
-                    if (!inheritIsDirty.ContainsKey(property.Name) || inheritIsDirty[property.Name])
+                    // IsDirtyIgnoredAttribute
+
+                    if (!inheritIsDirtyIgnored.ContainsKey(property.Name) || inheritIsDirtyIgnored[property.Name])
                     {
                         var isDirtyIgnoredAttribute = attributes.OfType<IsDirtyIgnoredAttribute>().SingleOrDefault();
                         if (isDirtyIgnoredAttribute != null)
                         {
                             if (isDirtyIgnoredAttribute.InheritAttributes)
-                                inheritIsDirty[property.Name] = true;
+                                inheritIsDirtyIgnored[property.Name] = true;
                             else
                                 IsDirtyIgnoredProperties.Add(property.Name);
                         }
                         else
                         {
-                            inheritIsDirty[property.Name] = false;
+                            inheritIsDirtyIgnored[property.Name] = false;
+                        }
+                    }
+
+                    // IsReadOnlyIgnoredAttribute
+
+                    if (!inheritIsReadOnlyIgnored.ContainsKey(property.Name) || inheritIsReadOnlyIgnored[property.Name])
+                    {
+                        var isReadOnlyIgnoredAttribute = attributes.OfType<IsReadOnlyIgnoredAttribute>().SingleOrDefault();
+                        if (isReadOnlyIgnoredAttribute != null)
+                        {
+                            if (isReadOnlyIgnoredAttribute.InheritAttributes)
+                                inheritIsReadOnlyIgnored[property.Name] = true;
+                            else
+                                IsReadOnlyIgnoredProperties.Add(property.Name);
+                        }
+                        else
+                        {
+                            inheritIsReadOnlyIgnored[property.Name] = false;
                         }
                     }
                 }

--- a/src/Smaragd/ViewModels/ViewModel.cs
+++ b/src/Smaragd/ViewModels/ViewModel.cs
@@ -31,6 +31,7 @@ namespace NKristek.Smaragd.ViewModels
 
         /// <inheritdoc />
         [IsDirtyIgnored]
+        [IsReadOnlyIgnored]
         public bool IsDirty
         {
             get => _isDirty;
@@ -41,6 +42,7 @@ namespace NKristek.Smaragd.ViewModels
 
         /// <inheritdoc />
         [IsDirtyIgnored]
+        [IsReadOnlyIgnored]
         public IViewModel Parent
         {
             get => _parent != null && _parent.TryGetTarget(out var parent) ? parent : null;
@@ -56,6 +58,7 @@ namespace NKristek.Smaragd.ViewModels
 
         /// <inheritdoc />
         [IsDirtyIgnored]
+        [IsReadOnlyIgnored]
         public virtual bool IsReadOnly
         {
             get => _isReadOnly;
@@ -66,6 +69,7 @@ namespace NKristek.Smaragd.ViewModels
 
         /// <inheritdoc />
         [IsDirtyIgnored]
+        [IsReadOnlyIgnored]
         public bool IsUpdating
         {
             get => _isUpdating;
@@ -73,8 +77,10 @@ namespace NKristek.Smaragd.ViewModels
         }
 
         private readonly IDictionary<string, ICommand> _commands = new Dictionary<string, ICommand>();
-        
+
         /// <inheritdoc />
+        [IsDirtyIgnored]
+        [IsReadOnlyIgnored]
         public IReadOnlyDictionary<string, ICommand> Commands => new ReadOnlyDictionary<string, ICommand>(_commands);
 
         /// <inheritdoc />
@@ -96,7 +102,7 @@ namespace NKristek.Smaragd.ViewModels
         protected override bool SetProperty<T>(ref T storage, T value, out T oldValue, [CallerMemberName] string propertyName = "")
         {
             oldValue = storage;
-            if (IsReadOnly && propertyName != nameof(IsReadOnly) && propertyName != nameof(IsDirty))
+            if (IsReadOnly && !IsReadOnlyIgnoredProperties.Contains(propertyName))
                 return false;
 
             var propertyWasChanged = base.SetProperty(ref storage, value, out oldValue, propertyName);

--- a/test/Smaragd.Tests/ViewModels/ViewModelTests.cs
+++ b/test/Smaragd.Tests/ViewModels/ViewModelTests.cs
@@ -301,6 +301,62 @@ namespace NKristek.Smaragd.Tests.ViewModels
             Assert.Equal(0, propertyChangedInvocations);
         }
 
+        private class InheritIsReadOnlyIgnoredParent
+            : ViewModel
+        {
+            private bool _testProperty;
+
+            public virtual bool TestProperty
+            {
+                get => _testProperty;
+                set => SetProperty(ref _testProperty, value, out _);
+            }
+
+            private bool _isReadOnlyIgnoredProperty;
+
+            [IsReadOnlyIgnored]
+            public virtual bool IsReadOnlyIgnoredProperty
+            {
+                get => _isReadOnlyIgnoredProperty;
+                set => SetProperty(ref _isReadOnlyIgnoredProperty, value, out _);
+            }
+        }
+
+        private class InheritIsReadOnlyIgnoredChild
+            : InheritIsReadOnlyIgnoredParent
+        {
+            private bool _testProperty;
+
+            [IsReadOnlyIgnored(InheritAttributes = true)]
+            public override bool TestProperty
+            {
+                get => _testProperty;
+                set => SetProperty(ref _testProperty, value, out _);
+            }
+
+            private bool _isReadOnlyIgnoredProperty;
+
+            [IsReadOnlyIgnored(InheritAttributes = true)]
+            public override bool IsReadOnlyIgnoredProperty
+            {
+                get => _isReadOnlyIgnoredProperty;
+                set => SetProperty(ref _isReadOnlyIgnoredProperty, value, out _);
+            }
+        }
+
+        [Fact]
+        public void SetProperty_IsReadOnly_IsReadOnlyIgnoredAttribute_InheritAttributes()
+        {
+            var viewModel = new InheritIsReadOnlyIgnoredChild
+            {
+                IsReadOnly = true,
+                TestProperty = true,
+                IsReadOnlyIgnoredProperty = true
+            };
+            Assert.False(viewModel.TestProperty);
+            Assert.True(viewModel.IsReadOnlyIgnoredProperty);
+        }
+
         [Theory]
         [InlineData(false, true)]
         [InlineData(true, false)]
@@ -378,6 +434,40 @@ namespace NKristek.Smaragd.Tests.ViewModels
                 IsDirty = false
             };
             Assert.False(viewModel.IsDirty);
+        }
+
+        [Fact]
+        public void Parent_can_be_set_when_IsReadOnly()
+        {
+            var parent = new TestViewModel();
+            var viewModel = new TestViewModel
+            {
+                IsReadOnly = true,
+                Parent = parent
+            };
+            Assert.NotNull(viewModel.Parent);
+        }
+
+        [Fact]
+        public void IsReadOnly_can_be_set_when_IsReadOnly()
+        {
+            var viewModel = new TestViewModel
+            {
+                IsReadOnly = true
+            };
+            viewModel.IsReadOnly = false;
+            Assert.False(viewModel.IsReadOnly);
+        }
+
+        [Fact]
+        public void IsUpdating_can_be_set_when_IsReadOnly()
+        {
+            var viewModel = new TestViewModel
+            {
+                IsReadOnly = true,
+                IsUpdating = true
+            };
+            Assert.True(viewModel.IsUpdating);
         }
 
         [Fact]


### PR DESCRIPTION
`IsReadOnlyIgnoredAttribute` class which can be used on properties of classes inheriting from `ViewModel`. When this attribute is present on a property, it (the property) can still be set even when `IsReadOnly` is set to `true`. The `InheritAttributes` property on `IsReadOnlyIgnoredAttribute` behaves like the one from `IsDirtyIgnoredAttribute`.

## Summary
<!-- Summarize your changes briefly -->
The implementation is based on the implementation for the `IsDirtyIgnoredAttribute`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This makes it possible to define properties that can still be set even when `IsReadOnly` is set to `true`.

## Details
<!--- Describe your changes in detail -->
- Added `IsReadOnlyIgnoredAttribute` class
- Modified `ComputedBindableBase` so it correctly detects the `IsReadOnlyIgnoredAttribute` on properties
- Modified `ViewModel` so `SetProperty` checks if the `IsReadOnlyIgnoredAttribute` is present on the property and add the attribute on the following properties:
    - IsDirty
    - Parent
    - IsReadOnly
    - IsUpdating
    - Commands (has currently no effect, maybe in the future)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have written/altered unit tests for the changes.
- [x] Only necessary files have been added/altered.
