### PR TITLE
Include icon in package instead of url

### DIFF
--- a/src/Smaragd/Smaragd.csproj
+++ b/src/Smaragd/Smaragd.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net45;net451;net452;net46;net461;net462;net47;net471;net472</TargetFrameworks>
     <LangVersion>latest</LangVersion>
@@ -13,7 +13,7 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/nkristek/Smaragd</PackageProjectUrl>
     <RepositoryUrl>https://github.com/nkristek/Smaragd.git</RepositoryUrl>
-    <PackageIconUrl>https://github.com/nkristek/Smaragd/blob/master/resources/icon-256x256.png?raw=true</PackageIconUrl>
+    <PackageIcon>icon-256x256.png</PackageIcon>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <RepositoryType>git</RepositoryType>
     <PackageTags>MVVM ViewModel INotifyPropertyChanged INotifyPropertyChanging INotifyDataErrorInfo</PackageTags>
@@ -25,4 +25,8 @@
     <NeutralLanguage>en</NeutralLanguage>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\..\resources\icon-256x256.png" Pack="true" Visible="false" PackagePath="\" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
Change project settings from using the deprecated `PackageIconUrl` tag to the new `PackageIcon` tag.

## Motivation and Context
 The `PackageIconUrl` tag is now deprecated and it is recommended to use the new `PackageIcon` tag. That way, the icon will get packed with the nupkg.

## Details
Since the icon is outside the src directory it has to be included, but the visibility can be set to false.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have written/altered unit tests for the changes.
- [x] Only necessary files have been added/altered.
