### PR TITLE
Refactor Disposable to check wether it already has been disposed 

### DIFF
--- a/src/Smaragd/Helpers/ActionDisposable.cs
+++ b/src/Smaragd/Helpers/ActionDisposable.cs
@@ -9,9 +9,9 @@ namespace NKristek.Smaragd.Helpers
     internal sealed class ActionDisposable
         : Disposable
     {
-        private readonly Action _disposeManagedResourcesAction;
+        private Action _disposeManagedResourcesAction;
 
-        private readonly Action _disposeNativeResourcesAction;
+        private Action _disposeNativeResourcesAction;
 
         /// <inheritdoc />
         /// <summary>
@@ -26,15 +26,14 @@ namespace NKristek.Smaragd.Helpers
         }
 
         /// <inheritdoc />
-        protected override void DisposeManagedResources()
-        {
-            _disposeManagedResourcesAction?.Invoke();
-        }
-
-        /// <inheritdoc />
-        protected override void DisposeNativeResources()
+        protected override void Dispose(bool managed = true)
         {
             _disposeNativeResourcesAction?.Invoke();
+            if (managed)
+                _disposeManagedResourcesAction?.Invoke();
+
+            _disposeNativeResourcesAction = null;
+            _disposeManagedResourcesAction = null;
         }
     }
 }

--- a/test/Smaragd.Tests/Helpers/DisposableTests.cs
+++ b/test/Smaragd.Tests/Helpers/DisposableTests.cs
@@ -14,18 +14,11 @@ namespace NKristek.Smaragd.Tests.Helpers
 
             public Action OnDisposeNativeResources;
 
-            protected override void DisposeManagedResources()
+            protected override void Dispose(bool managed = true)
             {
-                base.DisposeManagedResources();
-
-                OnDisposeManagedResources?.Invoke();
-            }
-
-            protected override void DisposeNativeResources()
-            {
-                base.DisposeNativeResources();
-
                 OnDisposeNativeResources?.Invoke();
+                if (managed)
+                    OnDisposeManagedResources?.Invoke();
             }
         }
 


### PR DESCRIPTION
## Summary
Refactor the `Disposable` class to be checking if already disposed in a thread safe manner.

## Motivation and Context
This change ensures that the `Dispose(bool managed)` function won't be called multiple times.

## Details
By using a volatile int the new implementation keeps track of whether it has been disposed or not.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have written/altered unit tests for the changes.
- [x] Only necessary files have been added/altered.
