### PR TITLE
Increase target framework of unit test project to .NET Core 3.0

### DIFF
--- a/src/Smaragd/Helpers/NotificationCache.cs
+++ b/src/Smaragd/Helpers/NotificationCache.cs
@@ -18,7 +18,7 @@ namespace NKristek.Smaragd.Helpers
         }
 
         /// <inheritdoc />
-        /// <exception cref="ArgumentNullException">If either <paramref name="propertyNameOfNotifyingProperty"/> or <paramref name="propertyNameToNotify"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentNullException">If either <paramref name="propertyNameOfNotifyingProperty"/> or <paramref name="propertyNameToNotify"/> is <see langword="null"/> or empty.</exception>
         /// <exception cref="ArgumentException">If <paramref name="propertyNameOfNotifyingProperty"/> and <paramref name="propertyNameToNotify"/> are equal (a property should not notify itself).</exception>
         public void AddPropertyNameToNotify(string propertyNameOfNotifyingProperty, string propertyNameToNotify)
         {
@@ -41,10 +41,11 @@ namespace NKristek.Smaragd.Helpers
         }
 
         /// <inheritdoc />
+        /// <exception cref="ArgumentNullException"><paramref name="propertyName"/> is <see langword="null"/> or empty.</exception>
         public IEnumerable<string> GetPropertyNamesToNotify(string propertyName)
         {
             if (String.IsNullOrEmpty(propertyName))
-                return Enumerable.Empty<string>();
+                throw new ArgumentNullException(nameof(propertyName));
 
             if (_cachedPropertyNamesToNotify.TryGetValue(propertyName, out var cachedPropertyNamesToNotify))
                 return cachedPropertyNamesToNotify.ToList();

--- a/test/Smaragd.Tests/Attributes/PropertySourceAttributeTests.cs
+++ b/test/Smaragd.Tests/Attributes/PropertySourceAttributeTests.cs
@@ -9,7 +9,9 @@ namespace NKristek.Smaragd.Tests.Attributes
         [Fact]
         public void Constructor_propertyNames_null_throws_ArgumentNullException()
         {
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
             Assert.Throws<ArgumentNullException>(() => new PropertySourceAttribute(null));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
         }
 
         [Fact]

--- a/test/Smaragd.Tests/Commands/ViewModelCommandTests.cs
+++ b/test/Smaragd.Tests/Commands/ViewModelCommandTests.cs
@@ -17,30 +17,30 @@ namespace NKristek.Smaragd.Tests.Commands
             public bool TestProperty
             {
                 get => _testProperty;
-                set => SetProperty(ref _testProperty, value, out _);
+                set => SetProperty(ref _testProperty, value);
             }
         }
 
         private class RelayViewModelCommand
             : ViewModelCommand<TestViewModel>
         {
-            private readonly Action<TestViewModel, object> _execute;
+            private readonly Action<TestViewModel?, object?> _execute;
 
-            private readonly Func<TestViewModel, object, bool> _canExecute;
+            private readonly Func<TestViewModel?, object?, bool>? _canExecute;
 
-            public RelayViewModelCommand(Action<TestViewModel, object> execute,
-                Func<TestViewModel, object, bool> canExecute = null)
+            public RelayViewModelCommand(Action<TestViewModel?, object?> execute,
+                Func<TestViewModel?, object?, bool>? canExecute = null)
             {
                 _execute = execute ?? throw new ArgumentNullException(nameof(execute));
                 _canExecute = canExecute;
             }
 
-            protected override bool CanExecute(TestViewModel viewModel, object parameter)
+            protected override bool CanExecute(TestViewModel? viewModel, object? parameter)
             {
                 return _canExecute?.Invoke(viewModel, parameter) ?? base.CanExecute(viewModel, parameter);
             }
 
-            protected override void Execute(TestViewModel viewModel, object parameter)
+            protected override void Execute(TestViewModel? viewModel, object? parameter)
             {
                 _execute.Invoke(viewModel, parameter);
             }
@@ -49,7 +49,7 @@ namespace NKristek.Smaragd.Tests.Commands
         private class DefaultViewModelCommand
             : ViewModelCommand<TestViewModel>
         {
-            protected override void Execute(TestViewModel viewModel, object parameter)
+            protected override void Execute(TestViewModel? viewModel, object? parameter)
             {
                 if (viewModel == null)
                     throw new ArgumentNullException(nameof(viewModel));
@@ -70,19 +70,19 @@ namespace NKristek.Smaragd.Tests.Commands
         private class CanExecuteSourceViewModelCommand
             : ViewModelCommand<TestViewModel>
         {
-            protected override bool CanExecute(TestViewModel viewModel, object parameter)
+            protected override bool CanExecute(TestViewModel? viewModel, object? parameter)
             {
-                return viewModel.TestProperty;
+                return viewModel?.TestProperty ?? false;
             }
 
             /// <inheritdoc />
-            protected override void OnContextPropertyChanged(object sender, PropertyChangedEventArgs e)
+            protected override void OnContextPropertyChanged(object? sender, PropertyChangedEventArgs? e)
             {
                 if (e == null || String.IsNullOrEmpty(e.PropertyName) || e.PropertyName.Equals(nameof(TestViewModel.TestProperty)))
                     NotifyCanExecuteChanged();
             }
 
-            protected override void Execute(TestViewModel viewModel, object parameter)
+            protected override void Execute(TestViewModel? viewModel, object? parameter)
             {
             }
         }

--- a/test/Smaragd.Tests/GCHelper.cs
+++ b/test/Smaragd.Tests/GCHelper.cs
@@ -4,7 +4,7 @@ namespace NKristek.Smaragd.Tests
 {
     internal static class GCHelper
     {
-        public static void TriggerGC()
+        internal static void TriggerGC()
         {
             GC.Collect();
             GC.WaitForPendingFinalizers();

--- a/test/Smaragd.Tests/Helpers/DisposableTests.cs
+++ b/test/Smaragd.Tests/Helpers/DisposableTests.cs
@@ -10,9 +10,9 @@ namespace NKristek.Smaragd.Tests.Helpers
         private class DisposableImpl
             : Disposable
         {
-            public Action OnDisposeManagedResources;
+            public Action? OnDisposeManagedResources;
 
-            public Action OnDisposeNativeResources;
+            public Action? OnDisposeNativeResources;
 
             protected override void Dispose(bool managed = true)
             {
@@ -65,13 +65,17 @@ namespace NKristek.Smaragd.Tests.Helpers
         }
 
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
-        private static void CreateDisposableInstance(Action onDisposeManagedResources, Action onDisposeNativeResources)
+        private static void CreateDisposableInstance(Action? onDisposeManagedResources, Action? onDisposeNativeResources)
         {
+#pragma warning disable IDE0059 // Unnecessary assignment of a value
+#pragma warning disable IDE0067 // Dispose objects before losing scope
             var instance = new DisposableImpl
+#pragma warning restore IDE0059 // Unnecessary assignment of a value
             {
                 OnDisposeManagedResources = onDisposeManagedResources,
                 OnDisposeNativeResources = onDisposeNativeResources
             };
+#pragma warning restore IDE0067 // Dispose objects before losing scope
         }
     }
 }

--- a/test/Smaragd.Tests/Helpers/NotificationCacheTests.cs
+++ b/test/Smaragd.Tests/Helpers/NotificationCacheTests.cs
@@ -27,13 +27,17 @@ namespace NKristek.Smaragd.Tests.Helpers
         [Fact]
         public void AddPropertyNameToNotify_PropertyNameOfNotifyingPropertyNull_ThrowsArgumentNullException()
         {
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
             Assert.Throws<ArgumentNullException>(() => NotificationCache.AddPropertyNameToNotify(null, FirstProperty));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
         }
 
         [Fact]
         public void AddPropertyNameToNotify_PropertyNameToNotifyNull_ThrowsArgumentNullException()
         {
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
             Assert.Throws<ArgumentNullException>(() => NotificationCache.AddPropertyNameToNotify(FirstProperty, null));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
         }
 
         [Fact]
@@ -43,9 +47,11 @@ namespace NKristek.Smaragd.Tests.Helpers
         }
 
         [Fact]
-        public void GetPropertyNamesToNotify_propertyName_null_returns_empty_collection()
+        public void GetPropertyNamesToNotify_propertyName_null_throws_ArgumentNullException()
         {
-            Assert.Empty(NotificationCache.GetPropertyNamesToNotify(null));
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+            Assert.Throws<ArgumentNullException>(() => NotificationCache.GetPropertyNamesToNotify(null));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
         }
 
         [Fact]

--- a/test/Smaragd.Tests/Helpers/WeakReferenceExtensionsTests.cs
+++ b/test/Smaragd.Tests/Helpers/WeakReferenceExtensionsTests.cs
@@ -12,8 +12,10 @@ namespace NKristek.Smaragd.Tests.Helpers
         [Fact]
         public void TargetOrDefault_null_weakreference_throws_ArgumentNullException()
         {
-            WeakReference<object> weakReference = null;
+            WeakReference<object>? weakReference = null;
+#pragma warning disable CS8604 // Possible null reference argument.
             Assert.Throws<ArgumentNullException>(() => weakReference.TargetOrDefault());
+#pragma warning restore CS8604 // Possible null reference argument.
         }
 
         [Fact]

--- a/test/Smaragd.Tests/Smaragd.Tests.csproj
+++ b/test/Smaragd.Tests/Smaragd.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>

--- a/test/Smaragd.Tests/Smaragd.Tests.csproj
+++ b/test/Smaragd.Tests/Smaragd.Tests.csproj
@@ -1,17 +1,18 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <LangVersion>8.0</LangVersion>
+    <Nullable>enable</Nullable>
 
     <IsPackable>false</IsPackable>
 
     <AssemblyName>NKristek.Smaragd.Tests</AssemblyName>
-
     <RootNamespace>NKristek.Smaragd.Tests</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>

--- a/test/Smaragd.Tests/Validation/FuncValidationTests.cs
+++ b/test/Smaragd.Tests/Validation/FuncValidationTests.cs
@@ -9,7 +9,9 @@ namespace NKristek.Smaragd.Tests.Validation
         [Fact]
         public void FuncValidation_Func_null_throws_ArgumentNullException()
         {
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
             Assert.Throws<ArgumentNullException>(() => new FuncValidation<int, bool>(null));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
         }
 
         [Theory]

--- a/test/Smaragd.Tests/Validation/PredicateValidationTests.cs
+++ b/test/Smaragd.Tests/Validation/PredicateValidationTests.cs
@@ -9,7 +9,9 @@ namespace NKristek.Smaragd.Tests.Validation
         [Fact]
         public void PredicateValidation_Func_null_throws_ArgumentNullException()
         {
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
             Assert.Throws<ArgumentNullException>(() => new PredicateValidation<int>(null));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
         }
 
         [Theory]

--- a/test/Smaragd.Tests/ViewModels/BindableTests.cs
+++ b/test/Smaragd.Tests/ViewModels/BindableTests.cs
@@ -12,82 +12,82 @@ namespace NKristek.Smaragd.Tests.ViewModels
         private class TestBindable
             : Bindable
         {
-            public object PropertyStorage;
+            public object? PropertyStorage;
 
-            public object Property
+            public object? Property
             {
                 get => PropertyStorage;
                 set => SetProperty(ref PropertyStorage, value);
             }
 
-            public WeakReference<object> WeakPropertyStorage;
+            public WeakReference<object>? WeakPropertyStorage;
 
-            public object WeakProperty
+            public object? WeakProperty
             {
                 get => WeakPropertyStorage?.TargetOrDefault();
                 set => SetProperty(ref WeakPropertyStorage, value);
             }
 
-            public string StringPropertyStorage;
+            public string? StringPropertyStorage;
 
-            public string StringProperty
+            public string? StringProperty
             {
                 get => StringPropertyStorage;
                 set => SetProperty(ref StringPropertyStorage, value);
             }
 
-            public WeakReference<string> WeakStringPropertyStorage;
+            public WeakReference<string>? WeakStringPropertyStorage;
 
-            public string WeakStringProperty
+            public string? WeakStringProperty
             {
                 get => WeakStringPropertyStorage?.TargetOrDefault();
                 set => SetProperty(ref WeakStringPropertyStorage, value);
             }
 
-            public void NotifyPropertyChangingExternal(string propertyName)
+            public void NotifyPropertyChangingExternal(string? propertyName)
             {
                 NotifyPropertyChanging(propertyName);
             }
 
-            public void NotifyPropertyChangedExternal(string propertyName)
+            public void NotifyPropertyChangedExternal(string? propertyName)
             {
                 NotifyPropertyChanged(propertyName);
             }
 
-            public bool SetPropertyExternal<T>(ref T storage, T value, IEqualityComparer<T> comparer, string propertyName)
+            public bool SetPropertyExternal<T>(ref T storage, T value, IEqualityComparer<T>? comparer, string? propertyName)
             {
-                return SetProperty(ref storage, value, comparer, propertyName);
+                return base.SetProperty(ref storage, value, comparer, propertyName);
             }
 
-            public bool SetPropertyExternal<T>(ref T storage, T value, out T oldValue, IEqualityComparer<T> comparer, string propertyName)
+            public bool SetPropertyExternal<T>(ref T storage, T value, out T oldValue, IEqualityComparer<T>? comparer, string? propertyName)
             {
-                return SetProperty(ref storage, value, out oldValue, comparer, propertyName);
+                return base.SetProperty(ref storage, value, out oldValue, comparer, propertyName);
             }
 
-            public bool SetPropertyExternal<T>(ref WeakReference<T> storage, T value, IEqualityComparer<T> comparer, string propertyName)
+            public bool SetPropertyExternal<T>(ref WeakReference<T>? storage, T? value, IEqualityComparer<T?>? comparer, string? propertyName)
                 where T : class
             {
-                return SetProperty(ref storage, value, comparer, propertyName);
+                return base.SetProperty(ref storage, value, comparer, propertyName);
             }
 
-            public bool SetPropertyExternal<T>(ref WeakReference<T> storage, T value, out T oldValue, IEqualityComparer<T> comparer, string propertyName)
+            public bool SetPropertyExternal<T>(ref WeakReference<T>? storage, T? value, out T? oldValue, IEqualityComparer<T?>? comparer, string? propertyName)
                 where T : class
             {
-                return SetProperty(ref storage, value, out oldValue, comparer, propertyName);
+                return base.SetProperty(ref storage, value, out oldValue, comparer, propertyName);
             }
         }
 
         private class StringSameLengthEqualityComparer
-            : IEqualityComparer<string>
+            : IEqualityComparer<string?>
         {
             /// <inheritdoc />
-            public bool Equals(string x, string y)
+            public bool Equals(string? x, string? y)
             {
                 return (x?.Length ?? 0) == (y?.Length ?? 0);
             }
 
             /// <inheritdoc />
-            public int GetHashCode(string obj)
+            public int GetHashCode(string? obj)
             {
                 return obj?.Length ?? 0;
             }
@@ -98,7 +98,7 @@ namespace NKristek.Smaragd.Tests.ViewModels
         [InlineData(null)]
         [InlineData("")]
         [InlineData(" ")]
-        public void NotifyPropertyChanging_raises_event_on_PropertyChanging(string propertyName)
+        public void NotifyPropertyChanging_raises_event_on_PropertyChanging(string? propertyName)
         {
             var invokedPropertyChangingEvents = new List<string>();
             var bindable = new TestBindable();
@@ -112,7 +112,7 @@ namespace NKristek.Smaragd.Tests.ViewModels
         [InlineData(null)]
         [InlineData("")]
         [InlineData(" ")]
-        public void NotifyPropertyChanged_raises_event_on_PropertyChanged(string propertyName)
+        public void NotifyPropertyChanged_raises_event_on_PropertyChanged(string? propertyName)
         {
             var invokedPropertyChangedEvents = new List<string>();
             var bindable = new TestBindable();
@@ -124,7 +124,7 @@ namespace NKristek.Smaragd.Tests.ViewModels
         [Theory]
         [InlineData(typeof(object))]
         [InlineData(null)]
-        public void SetProperty_sets_storage(object input)
+        public void SetProperty_sets_storage(object? input)
         {
             var bindable = new TestBindable();
             bindable.SetPropertyExternal(ref bindable.PropertyStorage, input, null, nameof(bindable.Property));
@@ -134,7 +134,7 @@ namespace NKristek.Smaragd.Tests.ViewModels
         [Theory]
         [InlineData(typeof(object))]
         [InlineData(null)]
-        public void SetProperty_weak_sets_storage(object input)
+        public void SetProperty_weak_sets_storage(object? input)
         {
             var bindable = new TestBindable();
             bindable.SetPropertyExternal(ref bindable.WeakPropertyStorage, input, null, nameof(bindable.WeakProperty));
@@ -144,7 +144,7 @@ namespace NKristek.Smaragd.Tests.ViewModels
         [Theory]
         [InlineData(null, typeof(object))]
         [InlineData(typeof(object), null)]
-        public void SetProperty_sets_old_value_of_storage(object initialValue, object input)
+        public void SetProperty_sets_old_value_of_storage(object? initialValue, object? input)
         {
             var bindable = new TestBindable
             {
@@ -158,7 +158,7 @@ namespace NKristek.Smaragd.Tests.ViewModels
         [Theory]
         [InlineData(null, typeof(object))]
         [InlineData(typeof(object), null)]
-        public void SetProperty_weak_sets_old_value_of_storage(object initialValue, object input)
+        public void SetProperty_weak_sets_old_value_of_storage(object? initialValue, object? input)
         {
             var bindable = new TestBindable
             {
@@ -204,7 +204,7 @@ namespace NKristek.Smaragd.Tests.ViewModels
         [Theory]
         [InlineData(typeof(object), 1)]
         [InlineData(null, 0)]
-        public void SetProperty_raises_event_on_PropertyChanging(object input, int expectedCountOfPropertyChangingEvents)
+        public void SetProperty_raises_event_on_PropertyChanging(object? input, int expectedCountOfPropertyChangingEvents)
         {
             var invokedPropertyChangingEvents = new List<string>();
             var bindable = new TestBindable();
@@ -216,7 +216,7 @@ namespace NKristek.Smaragd.Tests.ViewModels
         [Theory]
         [InlineData(typeof(object), 1)]
         [InlineData(null, 0)]
-        public void SetProperty_weak_raises_event_on_PropertyChanging(object input, int expectedCountOfPropertyChangingEvents)
+        public void SetProperty_weak_raises_event_on_PropertyChanging(object? input, int expectedCountOfPropertyChangingEvents)
         {
             var invokedPropertyChangingEvents = new List<string>();
             var bindable = new TestBindable();
@@ -228,7 +228,7 @@ namespace NKristek.Smaragd.Tests.ViewModels
         [Theory]
         [InlineData(typeof(object), 1)]
         [InlineData(null, 0)]
-        public void SetProperty_raises_event_on_PropertyChanged(object input, int expectedCountOfPropertyChangedEvents)
+        public void SetProperty_raises_event_on_PropertyChanged(object? input, int expectedCountOfPropertyChangedEvents)
         {
             var invokedPropertyChangedEvents = new List<string>();
             var bindable = new TestBindable();
@@ -240,7 +240,7 @@ namespace NKristek.Smaragd.Tests.ViewModels
         [Theory]
         [InlineData(typeof(object), 1)]
         [InlineData(null, 0)]
-        public void SetProperty_weak_raises_event_on_PropertyChanged(object input, int expectedCountOfPropertyChangedEvents)
+        public void SetProperty_weak_raises_event_on_PropertyChanged(object? input, int expectedCountOfPropertyChangedEvents)
         {
             var invokedPropertyChangedEvents = new List<string>();
             var bindable = new TestBindable();
@@ -290,7 +290,7 @@ namespace NKristek.Smaragd.Tests.ViewModels
         [Theory]
         [InlineData(null, typeof(object), true)]
         [InlineData(null, null, false)]
-        public void SetProperty_returns_if_value_was_different(object initialValue, object input, bool expectedResult)
+        public void SetProperty_returns_if_value_was_different(object? initialValue, object? input, bool expectedResult)
         {
             var bindable = new TestBindable
             {
@@ -302,7 +302,7 @@ namespace NKristek.Smaragd.Tests.ViewModels
         [Theory]
         [InlineData(null, typeof(object), true)]
         [InlineData(null, null, false)]
-        public void SetProperty_weak_returns_if_value_was_different(object initialValue, object input, bool expectedResult)
+        public void SetProperty_weak_returns_if_value_was_different(object? initialValue, object? input, bool expectedResult)
         {
             var bindable = new TestBindable
             {

--- a/test/Smaragd.Tests/ViewModels/DialogModelTests.cs
+++ b/test/Smaragd.Tests/ViewModels/DialogModelTests.cs
@@ -13,7 +13,7 @@ namespace NKristek.Smaragd.Tests.ViewModels
         [Theory]
         [InlineData(null, "1")]
         [InlineData("1", "2")]
-        public void Title_set(string initialValue, string valueToSet)
+        public void Title_set(string? initialValue, string valueToSet)
         {
             var viewModel = new TestDialogModel
             {

--- a/test/Smaragd.Tests/ViewModels/TreeViewModelTests.cs
+++ b/test/Smaragd.Tests/ViewModels/TreeViewModelTests.cs
@@ -113,7 +113,9 @@ namespace NKristek.Smaragd.Tests.ViewModels
         public void ReevaluateIsChecked_TreeChildrenNotOverridden()
         {
             var parent = new FileViewModel();
+#pragma warning disable IDE0059 // Unnecessary assignment of a value
             var child = new FileViewModel
+#pragma warning restore IDE0059 // Unnecessary assignment of a value
             {
                 Parent = parent,
                 IsChecked = true

--- a/test/Smaragd.Tests/ViewModels/ValidatingBindableTests.cs
+++ b/test/Smaragd.Tests/ViewModels/ValidatingBindableTests.cs
@@ -29,32 +29,32 @@ namespace NKristek.Smaragd.Tests.ViewModels
                 set => SetProperty(ref _anotherProperty, value);
             }
 
-            public void NotifyPropertyChangingExternal(string propertyName)
+            public void NotifyPropertyChangingExternal(string? propertyName)
             {
-                NotifyPropertyChanging(propertyName);
+                base.NotifyPropertyChanging(propertyName);
             }
 
-            public void NotifyPropertyChangedExternal(string propertyName)
+            public void NotifyPropertyChangedExternal(string? propertyName)
             {
-                NotifyPropertyChanged(propertyName);
+                base.NotifyPropertyChanged(propertyName);
             }
 
             public bool HasNotifiedErrorsChanged;
 
-            protected override void NotifyErrorsChanged([CallerMemberName] string propertyName = null)
+            protected override void NotifyErrorsChanged([CallerMemberName] string? propertyName = null)
             {
                 base.NotifyErrorsChanged(propertyName);
                 HasNotifiedErrorsChanged = true;
             }
 
-            public void NotifyErrorsChangedExternal(string propertyName)
+            public void NotifyErrorsChangedExternal(string? propertyName)
             {
-                NotifyErrorsChanged(propertyName);
+                base.NotifyErrorsChanged(propertyName);
             }
 
-            public void SetErrorsExternal(IEnumerable errors, [CallerMemberName] string propertyName = null)
+            public void SetErrorsExternal(IEnumerable? errors, [CallerMemberName] string? propertyName = null)
             {
-                SetErrors(errors, propertyName);
+                base.SetErrors(errors, propertyName);
             }
         }
 
@@ -165,7 +165,7 @@ namespace NKristek.Smaragd.Tests.ViewModels
         [InlineData("", 2)]
         [InlineData(nameof(TestBindable.Property), 1)]
         [InlineData("NotExistingProperty", 0)]
-        public void GetErrors_with_error(string propertyName, int expectedErrorCount)
+        public void GetErrors_with_error(string? propertyName, int expectedErrorCount)
         {
             var viewModel = new TestBindable();
             viewModel.SetErrorsExternal(Enumerable.Repeat("Value has to be at least 5.", 1), nameof(TestBindable.Property));
@@ -178,7 +178,7 @@ namespace NKristek.Smaragd.Tests.ViewModels
         [InlineData("")]
         [InlineData(nameof(TestBindable.Property))]
         [InlineData("NotExistingProperty")]
-        public void GetErrors_without_error(string propertyName)
+        public void GetErrors_without_error(string? propertyName)
         {
             var viewModel = new TestBindable();
             viewModel.SetErrorsExternal(Enumerable.Repeat("Value has to be at least 5.", 1), nameof(TestBindable.Property));

--- a/test/Smaragd.Tests/ViewModels/ViewModelTests.cs
+++ b/test/Smaragd.Tests/ViewModels/ViewModelTests.cs
@@ -16,53 +16,53 @@ namespace NKristek.Smaragd.Tests.ViewModels
         private class TestViewModel
             : ViewModel
         {
-            private object _property;
+            private object? _property;
 
-            public object Property
+            public object? Property
             {
                 get => _property;
                 set => SetProperty(ref _property, value);
             }
 
-            private WeakReference<object> _weakProperty;
+            private WeakReference<object>? _weakProperty;
 
-            public object WeakProperty
+            public object? WeakProperty
             {
                 get => _weakProperty?.TargetOrDefault();
                 set => SetProperty(ref _weakProperty, value);
             }
 
-            private object _isDirtyIgnoredProperty;
+            private object? _isDirtyIgnoredProperty;
 
             [IsDirtyIgnored]
-            public object IsDirtyIgnoredProperty
+            public object? IsDirtyIgnoredProperty
             {
                 get => _isDirtyIgnoredProperty;
                 set => SetProperty(ref _isDirtyIgnoredProperty, value);
             }
 
-            private WeakReference<object> _isDirtyIgnoredWeakProperty;
+            private WeakReference<object>? _isDirtyIgnoredWeakProperty;
 
             [IsDirtyIgnored]
-            public object IsDirtyIgnoredWeakProperty
+            public object? IsDirtyIgnoredWeakProperty
             {
                 get => _isDirtyIgnoredWeakProperty?.TargetOrDefault();
                 set => SetProperty(ref _isDirtyIgnoredWeakProperty, value);
             }
 
-            private object _isReadOnlyIgnoredProperty;
+            private object? _isReadOnlyIgnoredProperty;
 
             [IsReadOnlyIgnored]
-            public object IsReadOnlyIgnoredProperty
+            public object? IsReadOnlyIgnoredProperty
             {
                 get => _isReadOnlyIgnoredProperty;
                 set => SetProperty(ref _isReadOnlyIgnoredProperty, value);
             }
 
-            private WeakReference<object> _isReadOnlyIgnoredWeakProperty;
+            private WeakReference<object>? _isReadOnlyIgnoredWeakProperty;
 
             [IsReadOnlyIgnored]
-            public object IsReadOnlyIgnoredWeakProperty
+            public object? IsReadOnlyIgnoredWeakProperty
             {
                 get => _isReadOnlyIgnoredWeakProperty?.TargetOrDefault();
                 set => SetProperty(ref _isReadOnlyIgnoredWeakProperty, value);
@@ -76,9 +76,9 @@ namespace NKristek.Smaragd.Tests.ViewModels
                 set => SetProperty(ref _values, value);
             }
 
-            private WeakReference<ObservableCollection<int>> _weakValues;
+            private WeakReference<ObservableCollection<int>>? _weakValues;
 
-            public ObservableCollection<int> WeakValues
+            public ObservableCollection<int>? WeakValues
             {
                 get => _weakValues?.TargetOrDefault();
                 set => SetProperty(ref _weakValues, value);
@@ -93,28 +93,28 @@ namespace NKristek.Smaragd.Tests.ViewModels
                 set => SetProperty(ref _isDirtyIgnoredValues, value);
             }
 
-            private WeakReference<ObservableCollection<int>> _isDirtyIgnoredWeakValues;
+            private WeakReference<ObservableCollection<int>>? _isDirtyIgnoredWeakValues;
 
             [IsDirtyIgnored]
-            public ObservableCollection<int> IsDirtyIgnoredWeakValues
+            public ObservableCollection<int>? IsDirtyIgnoredWeakValues
             {
                 get => _isDirtyIgnoredWeakValues?.TargetOrDefault();
                 set => SetProperty(ref _isDirtyIgnoredWeakValues, value);
             }
 
-            public void NotifyPropertyChangingExternal(string propertyName)
+            public void NotifyPropertyChangingExternal(string? propertyName)
             {
-                NotifyPropertyChanging(propertyName);
+                base.NotifyPropertyChanging(propertyName);
             }
 
-            public void NotifyPropertyChangedExternal(string propertyName)
+            public void NotifyPropertyChangedExternal(string? propertyName)
             {
-                NotifyPropertyChanged(propertyName);
+                base.NotifyPropertyChanged(propertyName);
             }
 
-            public void SetErrorsExternal(IEnumerable errors, string propertyName)
+            public void SetErrorsExternal(IEnumerable? errors, string? propertyName)
             {
-                SetErrors(errors, propertyName);
+                base.SetErrors(errors, propertyName);
             }
         }
 
@@ -250,7 +250,7 @@ namespace NKristek.Smaragd.Tests.ViewModels
             public virtual bool Property
             {
                 get => _property;
-                set => SetProperty(ref _property, value, out _);
+                set => SetProperty(ref _property, value);
             }
 
             private bool _isDirtyIgnoredProperty;
@@ -259,7 +259,7 @@ namespace NKristek.Smaragd.Tests.ViewModels
             public virtual bool IsDirtyIgnoredProperty
             {
                 get => _isDirtyIgnoredProperty;
-                set => SetProperty(ref _isDirtyIgnoredProperty, value, out _);
+                set => SetProperty(ref _isDirtyIgnoredProperty, value);
             }
         }
 
@@ -408,18 +408,18 @@ namespace NKristek.Smaragd.Tests.ViewModels
 
         #region Parent
 
-        public static IEnumerable<object[]> Parent_set_input
+        public static IEnumerable<object?[]> Parent_set_input
         {
             get
             {
-                yield return new object[] { null, new TestViewModel() };
-                yield return new object[] { new TestViewModel(), null };
+                yield return new ViewModel?[] { null, new TestViewModel() };
+                yield return new ViewModel?[] { new TestViewModel(), null };
             }
         }
 
         [Theory]
         [MemberData(nameof(Parent_set_input))]
-        public void Parent_set(ViewModel initialValue, ViewModel valueToSet)
+        public void Parent_set(ViewModel? initialValue, ViewModel? valueToSet)
         {
             var viewModel = new TestViewModel
             {
@@ -533,7 +533,7 @@ namespace NKristek.Smaragd.Tests.ViewModels
             public virtual bool Property
             {
                 get => _property;
-                set => SetProperty(ref _property, value, out _);
+                set => SetProperty(ref _property, value);
             }
 
             private bool _isReadOnlyIgnoredProperty;
@@ -542,7 +542,7 @@ namespace NKristek.Smaragd.Tests.ViewModels
             public virtual bool IsReadOnlyIgnoredProperty
             {
                 get => _isReadOnlyIgnoredProperty;
-                set => SetProperty(ref _isReadOnlyIgnoredProperty, value, out _);
+                set => SetProperty(ref _isReadOnlyIgnoredProperty, value);
             }
         }
 
@@ -664,10 +664,17 @@ namespace NKristek.Smaragd.Tests.ViewModels
             [PropertySource(nameof(PropertySourceLoopFirstProperty))]
             public bool PropertySourceLoopSecondProperty { get; }
 
-            public void NotifyPropertyChangedExternal(string propertyName)
+            public void NotifyPropertyChangedExternal(string? propertyName)
             {
-                NotifyPropertyChanged(propertyName);
+                base.NotifyPropertyChanged(propertyName);
             }
+        }
+
+        [Fact]
+        public void NotifyPropertyChanged_PropertyName_null()
+        {
+            var viewModel = new PropertySourceViewModel();
+            viewModel.NotifyPropertyChangedExternal(null);
         }
 
         [Fact]
@@ -710,7 +717,7 @@ namespace NKristek.Smaragd.Tests.ViewModels
             public bool TestProperty
             {
                 get => _testProperty;
-                set => SetProperty(ref _testProperty, value, out _);
+                set => SetProperty(ref _testProperty, value);
             }
 
             [PropertySource(nameof(TestProperty))]


### PR DESCRIPTION
## Summary
Increase target framework of unit test project to .NET Core 3.0 and enable nullable reference types for unit tests.

## Motivation and Context
This improves on detecting issues related to nullable reference types.

## Details
- Increase target framework of unit test project to .NET Core 3.0
- Altered unit tests due to nullable reference types

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have written/altered unit tests for the changes.
- [x] Only necessary files have been added/altered.
