### PR TITLE
Improve XML documentation by expanding the inheritdoc tag

### DIFF
--- a/src/Smaragd/Attributes/PropertySourceAttribute.cs
+++ b/src/Smaragd/Attributes/PropertySourceAttribute.cs
@@ -22,7 +22,6 @@ namespace NKristek.Smaragd.Attributes
         /// </summary>
         public bool InheritAttributes { get; set; }
 
-        /// <inheritdoc />
         /// <summary>
         /// Initializes a new instance of the <see cref="PropertySourceAttribute" /> class with one or multiple names of properties the property depends on.
         /// </summary>

--- a/src/Smaragd/Smaragd.csproj
+++ b/src/Smaragd/Smaragd.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net45;net451;net452;net46;net461;net462;net47;net471;net472</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
@@ -27,6 +27,15 @@
 
   <ItemGroup>
     <None Include="..\..\resources\icon-256x256.png" Pack="true" Visible="false" PackagePath="\" />
+  </ItemGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
+    <NoWarn>$(NoWarn);IDT001</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
+    <PackageDownload Include="NETStandard.Library.Ref" Version="[2.1.0]" />
+    <InheritDocReference Include="$([MSBuild]::EnsureTrailingSlash('$(NugetPackageRoot)'))netstandard.library.ref\2.1.0\ref\netstandard2.1\netstandard.xml" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Smaragd/Smaragd.csproj
+++ b/src/Smaragd/Smaragd.csproj
@@ -28,4 +28,11 @@
   <ItemGroup>
     <None Include="..\..\resources\icon-256x256.png" Pack="true" Visible="false" PackagePath="\" />
   </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="SauceControl.InheritDoc" Version="0.4.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
 </Project>

--- a/src/Smaragd/Smaragd.csproj
+++ b/src/Smaragd/Smaragd.csproj
@@ -28,7 +28,11 @@
   <ItemGroup>
     <None Include="..\..\resources\icon-256x256.png" Pack="true" Visible="false" PackagePath="\" />
   </ItemGroup>
-
+  
+  <PropertyGroup>
+    <NoWarn>$(NoWarn);IDT004</NoWarn>
+  </PropertyGroup>
+    
   <PropertyGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
     <NoWarn>$(NoWarn);IDT001</NoWarn>
   </PropertyGroup>

--- a/src/Smaragd/Validation/FuncValidation.cs
+++ b/src/Smaragd/Validation/FuncValidation.cs
@@ -11,7 +11,6 @@ namespace NKristek.Smaragd.Validation
     {
         private readonly Func<TValue, TResult> _validationFunc;
 
-        /// <inheritdoc />
         /// <summary>
         /// Initializes a new instance of the <see cref="FuncValidation{TValue, TValidationResult}"/> class with the <paramref name="validationFunc"/> which is used to validate the value.
         /// </summary>

--- a/src/Smaragd/Validation/PredicateValidation.cs
+++ b/src/Smaragd/Validation/PredicateValidation.cs
@@ -11,7 +11,6 @@ namespace NKristek.Smaragd.Validation
     {
         private readonly Predicate<TValue> _validationPredicate;
 
-        /// <inheritdoc />
         /// <summary>
         /// Initializes a new instance of the <see cref="PredicateValidation{TValue}"/> class with the <paramref name="validationPredicate"/> which is used to validate the value.
         /// </summary>

--- a/src/Smaragd/ViewModels/ViewModel.cs
+++ b/src/Smaragd/ViewModels/ViewModel.cs
@@ -20,7 +20,9 @@ namespace NKristek.Smaragd.ViewModels
 
         private readonly HashSet<string> _isReadOnlyIgnoredProperties = new HashSet<string>();
 
-        /// <inheritdoc />
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ViewModel"/> class.
+        /// </summary>
         protected ViewModel()
         {
             InitAttributes();


### PR DESCRIPTION
## Summary
This includes a build-only dependency (no output will be generated nor will referencing code need a reference to this additional dependency) that expands the inheritdoc tag in the created output binaries at build time.

## Motivation and Context
Using this method, the generated output will include XML documentation that is better consumable.

## Details
- add dependency to [SauceControl.InheritDoc](https://github.com/saucecontrol/InheritDoc)
- include temporary fix for malformed .NET Standard XML documentation
- fix some invalid usage of the inheritdoc tag

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have written/altered unit tests for the changes.
- [x] Only necessary files have been added/altered.
